### PR TITLE
Small improvement of benchmark

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,10 @@ edition = "2021"
 [dependencies]
 bit_field = "0.10"
 serde = { version = "1.0", features = ["derive"] }
-random-string = "1.0"
 
 [dev-dependencies]
 criterion = "0.3"
+random-string = "1.0"
 
 [[bench]]
 name = "simple_benchmark"

--- a/benches/simple_benchmark.rs
+++ b/benches/simple_benchmark.rs
@@ -1,53 +1,109 @@
-use criterion::BenchmarkId;
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use kmers::naive_impl;
+/* std use */
+
+/* crates use */
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
 use random_string::generate;
 
-pub fn compute_rc_naive(b: &[u8]) -> u64 {
-    let K = 31;
-    let mut sum = 0u64;
-    for i in 0..(b.len() - K) {
-        let k = naive_impl::Kmer::from(&b[i..i + K]);
-        //k.to_reverse_complement();
-        sum += k.into_u64();
-    }
-    return sum;
+/* project use */
+use kmers::naive_impl;
+
+use kmers::encoding::Encoding as _;
+
+const K: usize = 31;
+
+pub fn compute_naive(b: &[u8]) -> u64 {
+    b.windows(K)
+        .map(|x| {
+            let k = naive_impl::Kmer::from(x);
+
+            k.into_u64()
+        })
+        .sum()
 }
 
-pub fn compute_rc(b: &[u8]) -> u64 {
-    const K: usize = 31;
-
-    let mut sum = 0u64;
+pub fn compute_xor10(b: &[u8]) -> u64 {
     let enc = kmers::encoding::xor10::Xor10;
-    for i in 0..(b.len() - K) {
-        let k = kmers::kmer::Kmer::<u64, K, { kmers::kmer::word_for_k::<u64, K>() }>::new(
-            &b[i..i + K],
-            &enc,
+
+    b.windows(K)
+        .map(|x| {
+            let k =
+                kmers::kmer::Kmer::<u64, K, { kmers::kmer::word_for_k::<u64, K>() }>::new(x, &enc);
+            k.num_bytes() as u64
+        })
+        .sum()
+}
+
+pub fn rc_naive(b: &[u8]) -> u64 {
+    b.windows(K)
+        .map(|x| {
+            let k = naive_impl::Kmer::from(x);
+            k.to_reverse_complement();
+            k.into_u64()
+        })
+        .sum::<u64>()
+}
+
+pub fn rc_xor10(b: &[u8]) -> u64 {
+    let enc = kmers::encoding::xor10::Xor10;
+
+    b.windows(K)
+        .map(|x| {
+            let k: [u64; 1] = enc.encode(x);
+            enc.rev_comp::<K>(k);
+            k[0]
+        })
+        .sum::<u64>()
+}
+
+pub fn construct(c: &mut Criterion) {
+    let charset = "ACGT";
+
+    let mut g = c.benchmark_group("construct");
+
+    for i in 8..16 {
+        let input = generate(1 << i, charset);
+        let bytes = input.as_bytes();
+
+        g.bench_with_input(BenchmarkId::new("naive", 1 << i), &bytes, |b, &s| {
+            b.iter(|| black_box(compute_naive(s)));
+        });
+
+        g.bench_with_input(
+            BenchmarkId::new("kme.rs::xor10", 1 << i),
+            &bytes,
+            |b, &s| {
+                b.iter(|| black_box(compute_xor10(s)));
+            },
         );
-        sum += k.num_bytes() as u64;
     }
-    return sum;
+}
+
+pub fn reverse_complement(c: &mut Criterion) {
+    let charset = "ACGT";
+
+    let mut g = c.benchmark_group("reverse_complement");
+
+    for i in 8..16 {
+        let input = generate(1 << i, charset);
+        let bytes = input.as_bytes();
+
+        g.bench_with_input(BenchmarkId::new("naive", 1 << i), &bytes, |b, &s| {
+            b.iter(|| black_box(rc_naive(s)));
+        });
+
+        g.bench_with_input(
+            BenchmarkId::new("kme.rs::xor10", 1 << i),
+            &bytes,
+            |b, &s| {
+                b.iter(|| black_box(rc_xor10(s)));
+            },
+        );
+    }
 }
 
 pub fn criterion_benchmark(c: &mut Criterion) {
-    let charset = "ACGT";
-    let input = generate(1_000_000, charset);
-    let bytes = input.as_bytes();
-    c.bench_with_input(
-        BenchmarkId::new("construct naive independent", "1M"),
-        &bytes,
-        |b, &s| {
-            b.iter(|| compute_rc_naive(&s));
-        },
-    );
-
-    c.bench_with_input(
-        BenchmarkId::new("construct kme.rs independent", "1M"),
-        &bytes,
-        |b, &s| {
-            b.iter(|| compute_rc(&s));
-        },
-    );
+    construct(c);
+    reverse_complement(c);
 }
 
 criterion_group!(benches, criterion_benchmark);


### PR DESCRIPTION
Run benchmark on sequence length between `2^i` with `i` is between 8 and 16 to check behaviour of benchmark on different length (check linearity).

Add reverse complement benchmark.

Maybe benchmark code is too rustic, I can rewrite it in more readable way.