### PR TITLE
Make `seq_vector` a feature so that library compiles on Windows again

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,10 @@ edition = "2021"
 bit_field = "0.10"
 serde = { version = "1.0", features = ["derive"] }
 num = "0.4.0"
-simple-sds = {git = "https://github.com/thejasonfan/simple-sds", branch = "serde_compat"}
+simple-sds = {git = "https://github.com/thejasonfan/simple-sds", branch = "serde_compat", optional = true }
+
+[features]
+seq-vector = ["dep:simple-sds"]
 
 [dev-dependencies]
 criterion = "0.3"

--- a/src/naive_impl/mod.rs
+++ b/src/naive_impl/mod.rs
@@ -3,6 +3,9 @@ pub mod canonical_kmer_iterator;
 mod kmer;
 
 pub mod hash;
+
+// Simple-sds does not compile on windows, so we make seq_vector an optional feature
+#[cfg(feature = "seq-vector")]
 pub mod seq_vector;
 
 // re-exports

--- a/src/naive_impl/seq_vector/minimizers.rs
+++ b/src/naive_impl/seq_vector/minimizers.rs
@@ -19,12 +19,12 @@ impl DQMer {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct MappedMinimizer {
-    word: u64,  // u64 representation
+    word: u64,      // u64 representation
     pub pos: usize, // position in sequence
 }
 
 impl MappedMinimizer {
-    pub fn as_u64(&self) -> u64{
+    pub fn as_u64(&self) -> u64 {
         self.word
     }
 }


### PR DESCRIPTION
A `dev` solution for issue #15 where `SeqVector` and `simple-sds` dependencies introduce compilation issues on Windows.

Todos before merge into `main`:
- CI with windows
- Update docs
- Maybe cut a semver version?